### PR TITLE
[PATCH] net: rose: Fix Null pointer dereference in rose_send_frame()

### DIFF
--- a/net/rose/rose_link.c
+++ b/net/rose/rose_link.c
@@ -96,6 +96,9 @@ static int rose_send_frame(struct sk_buff *skb, struct rose_neigh *neigh)
 {
 	ax25_address *rose_call;
 	ax25_cb *ax25s;
+	
+	if (!neigh->dev)
+		return -ENODEV;
 
 	if (ax25cmp(&rose_callsign, &null_ax25_address) == 0)
 		rose_call = (ax25_address *)neigh->dev->dev_addr;


### PR DESCRIPTION
In rose_send_frame(), when comparing two ax.25 addresses, it assigns rose_call to either global ROSE callsign or default port, but when the former block triggers and rose_call is assigned by (ax25_address *)neigh->dev->dev_addr, a NULL pointer is dereferenced by 'neigh' when dereferencing 'dev'.

- net/rose/rose_link.c
This bug seems to get triggered in this line:

rose_call = (ax25_address *)neigh->dev->dev_addr;

Fix it by checking NULL condition for neigh->dev.